### PR TITLE
Добрый день.

### DIFF
--- a/GeekFit/GeekFit/Core/AppDelegate.swift
+++ b/GeekFit/GeekFit/Core/AppDelegate.swift
@@ -20,7 +20,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         GMSServices.provideAPIKey("AIzaSyCrYGvnoqcy0b5zArPhVeOyOnhdsofsMKQ")
         
-        if #available(iOS 12, *) {
+        if #available(iOS 13, *) {
+        } else {
             window = UIWindow()
             window?.makeKeyAndVisible()
             


### PR DESCRIPTION
1. Утечек не нашел, но нашел что из-за поддержки iOS 12 MapViewController создавался дважды (один раз в ScneneDelegate, второй соответственно в AppDelegate). Убрал лишний вызов.
2. В основном больше всего исполнялись функции, которые порождали создание новых экранов (загрузка сториборда, инициализация класса), остальные выполнялись на уровне погрешности (1-3 мс). Три основных функций, исполняющихся наиболее продолжительное время:

AppManager.start() 58ms
ApplicationCoordinator.start 57ms
AppManager.getScreenPage<A> 35ms